### PR TITLE
Fix missing profile view

### DIFF
--- a/match-reservation-system/src/views/Profile.vue
+++ b/match-reservation-system/src/views/Profile.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="max-w-lg mx-auto mt-8 p-4 bg-white rounded shadow">
+    <h1 class="text-2xl font-bold mb-4">个人中心</h1>
+    <p class="text-gray-600">该页面正在建设中，敬请期待。</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+// 这里可以添加后续的逻辑
+</script>
+
+<style scoped>
+/* 预留样式 */
+</style>


### PR DESCRIPTION
## Summary
- add placeholder Profile.vue to satisfy router

## Testing
- `npm run build` *(fails: vue-tsc Permission denied)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68551f9cb49483288c80c0a96cb4c686